### PR TITLE
Adds more support for changing 'return'  and 'throw' statements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.spongepowered:mixin:0.8")
+    compileOnly("org.spongepowered:mixin:0.8.5")
     compileOnly("org.apache.commons:commons-lang3:3.3.2")
     compileOnly("org.ow2.asm:asm-debug-all:5.2")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.spongepowered:mixin:0.8.5")
+    compileOnly("org.spongepowered:mixin:0.8")
     compileOnly("org.apache.commons:commons-lang3:3.3.2")
     compileOnly("org.ow2.asm:asm-debug-all:5.2")
 }

--- a/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
+++ b/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
@@ -2,7 +2,7 @@ package com.llamalad7.mixinextras;
 
 import com.llamalad7.mixinextras.injector.*;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperationInjectionInfo;
-import org.spongepowered.asm.mixin.injection.InjectionPoint;
+import com.llamalad7.mixinextras.utils.CompatibilityHelper;
 import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
 
 public class MixinExtrasBootstrap {
@@ -26,8 +26,9 @@ public class MixinExtrasBootstrap {
             InjectionInfo.register(WrapOperationInjectionInfo.class);
             InjectionInfo.register(WrapWithConditionInjectionInfo.class);
             InjectionInfo.register(InitVariableInjectionInfo.class);
+            InjectionInfo.register(RedirectExitInjectionInfo.class);
 
-            InjectionPoint.register(BeforeThrow.class, "MixinExtras");
+            CompatibilityHelper.registerInjectionPoint(BeforeThrow.class, "MixinExtras", BeforeThrow.BeforeThrowNamespaced.class);
         }
     }
 

--- a/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
+++ b/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
@@ -28,6 +28,7 @@ public class MixinExtrasBootstrap {
             InjectionInfo.register(WrapWithConditionInjectionInfo.class);
             InjectionInfo.register(InitVariableInjectionInfo.class);
             InjectionInfo.register(RedirectExitInjectionInfo.class);
+            InjectionInfo.register(ModifyThrowValueInjectionInfo.class);
 
             CompatibilityHelper.registerInjectionPoint(BeforeThrow.class, "MixinExtras", BeforeThrow.BeforeThrowNamespaced.class);
         }

--- a/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
+++ b/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
@@ -2,6 +2,7 @@ package com.llamalad7.mixinextras;
 
 import com.llamalad7.mixinextras.injector.*;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperationInjectionInfo;
+import com.llamalad7.mixinextras.point.BeforeThrow;
 import com.llamalad7.mixinextras.utils.CompatibilityHelper;
 import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
 

--- a/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
+++ b/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
@@ -2,6 +2,7 @@ package com.llamalad7.mixinextras;
 
 import com.llamalad7.mixinextras.injector.*;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperationInjectionInfo;
+import org.spongepowered.asm.mixin.injection.InjectionPoint;
 import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
 
 public class MixinExtrasBootstrap {
@@ -24,6 +25,9 @@ public class MixinExtrasBootstrap {
             InjectionInfo.register(ModifyReturnValueInjectionInfo.class);
             InjectionInfo.register(WrapOperationInjectionInfo.class);
             InjectionInfo.register(WrapWithConditionInjectionInfo.class);
+            InjectionInfo.register(InitVariableInjectionInfo.class);
+
+            InjectionPoint.register(BeforeThrow.class, "MixinExtras");
         }
     }
 

--- a/src/main/java/com/llamalad7/mixinextras/injector/BeforeThrow.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/BeforeThrow.java
@@ -58,4 +58,12 @@ public class BeforeThrow extends InjectionPoint {
 
         return found;
     }
+
+    @AtCode("MIXINEXTRAS:THROW")
+    public static class BeforeThrowNamespaced extends BeforeThrow {
+
+        public BeforeThrowNamespaced(InjectionPointData data) {
+            super(data);
+        }
+    }
 }

--- a/src/main/java/com/llamalad7/mixinextras/injector/BeforeThrow.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/BeforeThrow.java
@@ -1,0 +1,61 @@
+package com.llamalad7.mixinextras.injector;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.spongepowered.asm.mixin.injection.IInjectionPointContext;
+import org.spongepowered.asm.mixin.injection.InjectionPoint;
+import org.spongepowered.asm.mixin.injection.struct.InjectionPointData;
+
+import java.util.Collection;
+import java.util.ListIterator;
+
+/**
+ * @see org.spongepowered.asm.mixin.injection.points.BeforeReturn
+ */
+@InjectionPoint.AtCode("THROW")
+public class BeforeThrow extends InjectionPoint {
+
+    private final int ordinal;
+
+    public BeforeThrow(InjectionPointData data) {
+        super(data);
+
+        this.ordinal = data.getOrdinal();
+    }
+
+    @Override
+    public boolean checkPriority(int targetPriority, int ownerPriority) {
+        return true;
+    }
+
+    @Override
+    public RestrictTargetLevel getTargetRestriction(IInjectionPointContext context) {
+        return RestrictTargetLevel.ALLOW_ALL;
+    }
+
+    @Override
+    public boolean find(String desc, InsnList insns, Collection<AbstractInsnNode> nodes) {
+        boolean found = false;
+
+        int throwOpcode = Opcodes.ATHROW;
+        int ordinal = 0;
+
+        ListIterator<AbstractInsnNode> iter = insns.iterator();
+        while (iter.hasNext()) {
+            AbstractInsnNode insn = iter.next();
+
+            if (insn instanceof InsnNode && insn.getOpcode() == throwOpcode) {
+                if (this.ordinal == -1 || this.ordinal == ordinal) {
+                    nodes.add(insn);
+                    found = true;
+                }
+
+                ordinal++;
+            }
+        }
+
+        return found;
+    }
+}

--- a/src/main/java/com/llamalad7/mixinextras/injector/InitVariable.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/InitVariable.java
@@ -1,0 +1,36 @@
+package com.llamalad7.mixinextras.injector;
+
+import org.spongepowered.asm.mixin.injection.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InitVariable {
+    String[] method();
+
+    Slice slice() default @Slice;
+
+    At at();
+
+    int ordinal() default -1;
+
+    int index() default -1;
+
+    String[] name() default {};
+
+    boolean argsOnly() default false;
+
+    boolean remap() default true;
+
+    int require() default -1;
+
+    int expect() default 1;
+
+    int allow() default -1;
+
+    String constraints() default "";
+}

--- a/src/main/java/com/llamalad7/mixinextras/injector/InitVariableInjectionInfo.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/InitVariableInjectionInfo.java
@@ -1,0 +1,21 @@
+package com.llamalad7.mixinextras.injector;
+
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.mixin.injection.code.Injector;
+import org.spongepowered.asm.mixin.injection.modify.LocalVariableDiscriminator;
+import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
+import org.spongepowered.asm.mixin.transformer.MixinTargetContext;
+
+@InjectionInfo.AnnotationType(InitVariable.class)
+@InjectionInfo.HandlerPrefix("initVariable")
+public class InitVariableInjectionInfo extends InjectionInfo {
+    public InitVariableInjectionInfo(MixinTargetContext mixin, MethodNode method, AnnotationNode annotation) {
+        super(mixin, method, annotation);
+    }
+
+    @Override
+    protected Injector parseInjector(AnnotationNode injectAnnotation) {
+        return new InitVariableInjector(this, LocalVariableDiscriminator.parse(injectAnnotation));
+    }
+}

--- a/src/main/java/com/llamalad7/mixinextras/injector/InitVariableInjector.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/InitVariableInjector.java
@@ -1,0 +1,160 @@
+package com.llamalad7.mixinextras.injector;
+
+import com.llamalad7.mixinextras.utils.CompatibilityHelper;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.*;
+import org.spongepowered.asm.mixin.injection.InjectionPoint;
+import org.spongepowered.asm.mixin.injection.code.Injector;
+import org.spongepowered.asm.mixin.injection.modify.InvalidImplicitDiscriminatorException;
+import org.spongepowered.asm.mixin.injection.modify.LocalVariableDiscriminator;
+import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
+import org.spongepowered.asm.mixin.injection.struct.InjectionNodes.InjectionNode;
+import org.spongepowered.asm.mixin.injection.struct.Target;
+import org.spongepowered.asm.mixin.injection.throwables.InjectionError;
+
+import java.util.List;
+
+/**
+ * @see org.spongepowered.asm.mixin.injection.modify.ModifyVariableInjector
+ */
+public class InitVariableInjector extends Injector {
+
+    static class Context extends LocalVariableDiscriminator.Context {
+
+        final InsnList insns = new InsnList();
+
+        public Context(InjectionInfo info, Type returnType, boolean argsOnly, Target target, AbstractInsnNode node) {
+            super(info, returnType, argsOnly, target, node);
+        }
+    }
+
+    private final LocalVariableDiscriminator discriminator;
+
+    public InitVariableInjector(InjectionInfo info, LocalVariableDiscriminator discriminator) {
+        super(info, "@InitVariable");
+        this.discriminator = discriminator;
+    }
+
+    protected String getTargetNodeKey(Target target, InjectionNode node) {
+        return String.format("localcontext(%s,%s,#%s)", this.returnType, this.discriminator.isArgsOnly() ? "argsOnly" : "fullFrame", node.getId());
+    }
+
+    @Override
+    protected void preInject(Target target, InjectionNode injectionNode) {
+        String key = this.getTargetNodeKey(target, injectionNode);
+        if (injectionNode.hasDecoration(key)) {
+            return; // already have a suitable context
+        }
+
+        // We go to the next frame to get the locals there, since
+        // the uninitialized variable is probably not present yet
+        AbstractInsnNode node = injectionNode.getCurrentTarget();
+        while(node != null && !(node instanceof FrameNode)) {
+            if(node instanceof JumpInsnNode) {
+                node = ((JumpInsnNode) node).label;
+            }
+            node = node.getNext();
+        }
+
+        Context context = new Context(this.info, this.returnType, this.discriminator.isArgsOnly(), target, node);
+        injectionNode.decorate(key, context);
+    }
+
+    @Override
+    protected void inject(Target target, InjectionNode node) {
+        if (node.isReplaced()) {
+            throw CompatibilityHelper.makeInvalidInjectionException(this.info,
+                String.format(
+                        "Target of %s annotation was removed by another injector in %s in %s",
+                        this.annotationType, target, this
+                ));
+        }
+
+        Context context = node.getDecoration(this.getTargetNodeKey(target, node));
+        if (context == null) {
+            throw new InjectionError(String.format(
+                    "%s injector target is missing CONTEXT decoration for %s. PreInjection failure or illegal internal state change",
+                    this.annotationType, this.info));
+        }
+
+        // If the context is being reused (because two identical injectors are targetting this node)
+        // then the insns SHOULD have been drained by the previous insertBefore. If the list hasn't
+        // been cleared for some reason then something probably went wrong during the previous inject
+        if (context.insns.size() > 0) {
+            throw new InjectionError(String.format(
+                    "%s injector target has contaminated CONTEXT decoration for %s. Check for previous errors.",
+                    this.annotationType, this.info));
+        }
+
+        this.checkTargetForNode(target, node, InjectionPoint.RestrictTargetLevel.ALLOW_ALL);
+
+        InjectorData handler = new InjectorData(target, "handler", false);
+
+        if (this.returnType == Type.VOID_TYPE) {
+            throw CompatibilityHelper.makeInvalidInjectionException(this.info,
+                    String.format(
+                            "%s %s method %s from %s has invalid signature, cannot return a VOID type.",
+                            this.annotationType, handler, this, this.info.getMixin()
+                    ));
+        }
+
+        this.validateParams(handler, this.returnType);
+
+        Target.Extension extraStack = target.extendStack();
+
+        try {
+            int local = this.discriminator.findLocal(context);
+            if (local > -1) {
+                this.inject(context, handler, extraStack, local);
+            }
+        } catch (InvalidImplicitDiscriminatorException ex) {
+            throw CompatibilityHelper.makeInvalidInjectionException(this.info,
+                    String.format(
+                            "%s implicit variable setter injection failed in %s in %s",
+                            this.annotationType, target, this
+                    ));
+        }
+
+        extraStack.apply();
+        target.insns.insertBefore(node.getCurrentTarget(), context.insns);
+    }
+
+    private void inject(Context context, InjectorData handler, Target.Extension extraStack, int local) {
+        if (!this.isStatic) {
+            context.insns.add(new VarInsnNode(Opcodes.ALOAD, 0));
+            extraStack.add();
+        }
+
+        // Unlike ModifyVariable, SetVariable doesn't load the previous value
+
+        if (handler.captureTargetArgs > 0) {
+            this.pushArgs(handler.target.arguments, context.insns, handler.target.getArgIndices(), 0, handler.captureTargetArgs, extraStack);
+        }
+
+        this.invokeHandler(context.insns);
+        context.insns.add(new VarInsnNode(this.returnType.getOpcode(Opcodes.ISTORE), local));
+    }
+
+    @Override
+    protected void sanityCheck(Target target, List<InjectionPoint> injectionPoints) {
+        super.sanityCheck(target, injectionPoints);
+
+        int ordinal = this.discriminator.getOrdinal();
+        if (ordinal < -1) {
+            throw CompatibilityHelper.makeInvalidInjectionException(this.info,
+                    String.format(
+                            "%s annotation has invalid ordinal %s specified in %s in %s",
+                            this.annotationType, ordinal, target, this
+                    ));
+        }
+
+        if (this.discriminator.getIndex() == 0 && !this.isStatic) {
+            throw CompatibilityHelper.makeInvalidInjectionException(this.info,
+                    String.format(
+                        "%s annotation has invalid index 0 specified in non-static variable setter in %s in %s",
+                        this.annotationType, target, this
+            ));
+        }
+    }
+}

--- a/src/main/java/com/llamalad7/mixinextras/injector/ModifyThrowValue.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/ModifyThrowValue.java
@@ -1,0 +1,27 @@
+package com.llamalad7.mixinextras.injector;
+
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ModifyThrowValue {
+    String[] method();
+
+    At[] at();
+
+    Slice[] slice() default {};
+
+    boolean remap() default true;
+
+    int require() default -1;
+
+    int expect() default 1;
+
+    int allow() default -1;
+}

--- a/src/main/java/com/llamalad7/mixinextras/injector/ModifyThrowValueInjectionInfo.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/ModifyThrowValueInjectionInfo.java
@@ -1,0 +1,21 @@
+package com.llamalad7.mixinextras.injector;
+
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.mixin.injection.code.Injector;
+import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
+import org.spongepowered.asm.mixin.injection.struct.InjectionInfo.HandlerPrefix;
+import org.spongepowered.asm.mixin.transformer.MixinTargetContext;
+
+@InjectionInfo.AnnotationType(ModifyThrowValue.class)
+@HandlerPrefix("modifyThrowValue")
+public class ModifyThrowValueInjectionInfo extends InjectionInfo {
+    public ModifyThrowValueInjectionInfo(MixinTargetContext mixin, MethodNode method, AnnotationNode annotation) {
+        super(mixin, method, annotation);
+    }
+
+    @Override
+    protected Injector parseInjector(AnnotationNode injectAnnotation) {
+        return new ModifyThrowValueInjector(this);
+    }
+}

--- a/src/main/java/com/llamalad7/mixinextras/injector/RedirectExit.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/RedirectExit.java
@@ -1,0 +1,27 @@
+package com.llamalad7.mixinextras.injector;
+
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedirectExit {
+    String[] method();
+
+    At[] at();
+
+    Slice[] slice() default {};
+
+    boolean remap() default true;
+
+    int require() default -1;
+
+    int expect() default 1;
+
+    int allow() default -1;
+}

--- a/src/main/java/com/llamalad7/mixinextras/injector/RedirectExitInjectionInfo.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/RedirectExitInjectionInfo.java
@@ -1,0 +1,21 @@
+package com.llamalad7.mixinextras.injector;
+
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.mixin.injection.code.Injector;
+import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
+import org.spongepowered.asm.mixin.transformer.MixinTargetContext;
+
+@InjectionInfo.AnnotationType(RedirectExit.class)
+@InjectionInfo.HandlerPrefix("redirectExit")
+public class RedirectExitInjectionInfo extends InjectionInfo {
+
+    public RedirectExitInjectionInfo(MixinTargetContext mixin, MethodNode method, AnnotationNode annotation) {
+        super(mixin, method, annotation);
+    }
+
+    @Override
+    protected Injector parseInjector(AnnotationNode injectAnnotation) {
+        return new RedirectExitInjector(this);
+    }
+}

--- a/src/main/java/com/llamalad7/mixinextras/injector/RedirectExitInjector.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/RedirectExitInjector.java
@@ -1,0 +1,140 @@
+package com.llamalad7.mixinextras.injector;
+
+import com.llamalad7.mixinextras.utils.CompatibilityHelper;
+import com.llamalad7.mixinextras.utils.InjectorUtils;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.*;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.injection.InjectionPoint;
+import org.spongepowered.asm.mixin.injection.code.Injector;
+import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
+import org.spongepowered.asm.mixin.injection.struct.InjectionNodes.InjectionNode;
+import org.spongepowered.asm.mixin.injection.struct.Target;
+import org.spongepowered.asm.util.Annotations;
+
+import java.util.List;
+import java.util.Set;
+
+public class RedirectExitInjector extends Injector {
+
+    class Meta {
+
+        public static final String KEY = "mixinextras_exitRedirector";
+
+        final int priority;
+
+        final boolean isFinal;
+
+        final String name;
+
+        final String desc;
+
+        public Meta(int priority, boolean isFinal, String name, String desc) {
+            this.priority = priority;
+            this.isFinal = isFinal;
+            this.name = name;
+            this.desc = desc;
+        }
+
+        RedirectExitInjector getOwner() {
+            return RedirectExitInjector.this;
+        }
+
+    }
+
+    private final Meta meta;
+
+    public RedirectExitInjector(InjectionInfo info) {
+        super(info, "@RedirectExit");
+
+        int priority = CompatibilityHelper.getMixin(info).getPriority();
+        boolean isFinal = Annotations.getVisible(this.methodNode, Final.class) != null;
+        this.meta = new Meta(priority, isFinal, this.info.toString(), this.methodNode.desc);
+    }
+
+    @Override
+    protected void addTargetNode(Target target, List<InjectionNode> myNodes, AbstractInsnNode insn, Set<InjectionPoint> nominators) {
+        InjectionNode node = target.getInjectionNode(insn);
+
+        if (node != null ) {
+            Meta other = node.getDecoration(Meta.KEY);
+
+            if (other != null && other.getOwner() != this) {
+                if (other.priority >= this.meta.priority) {
+                    CompatibilityHelper.injectorLoggerWarn("{} conflict. Skipping {} with priority {}, already redirected by {} with priority {}",
+                            this.annotationType, this.info, this.meta.priority, other.name, other.priority);
+                    return;
+                } else if (other.isFinal) {
+                    throw CompatibilityHelper.makeInvalidInjectionException(this.info,
+                            String.format(
+                                    "%s conflict: %s failed because target was already remapped by %s",
+                                    this.annotationType, this, other.name
+                            ));
+                }
+            }
+        }
+
+        InjectionNode targetNode = target.addInjectionNode(insn);
+        targetNode.decorate(Meta.KEY, this.meta);
+        myNodes.add(targetNode);
+    }
+
+    @Override
+    protected void inject(Target target, InjectionNode node) {
+        if (!this.preInject(node)) {
+            return;
+        }
+
+        if (node.isReplaced()) {
+            throw new UnsupportedOperationException("Exit-Redirector target failure for " + this.info);
+        }
+        this.checkTargetModifiers(target, false);
+        InjectorData data = new InjectorData(target, "exit redirector");
+        int opcode = node.getOriginalTarget().getOpcode();
+        boolean hasParameter = false;
+        if(opcode == Opcodes.ATHROW) {
+            this.validateParams(data, Type.VOID_TYPE, Type.getType(Throwable.class));
+            hasParameter = true;
+        } else if(opcode >= Opcodes.IRETURN && opcode <= Opcodes.ARETURN) {
+            this.validateParams(data, Type.VOID_TYPE, target.returnType);
+            hasParameter = true;
+        } else if(opcode == Opcodes.RETURN) {
+            this.validateParams(data, Type.VOID_TYPE);
+        } else {
+            throw CompatibilityHelper.makeInvalidInjectionException(this.info,
+                    String.format(
+                            "%s annotation on is targeting an invalid insn in %s in %s",
+                            this.annotationType, target, this
+                    ));
+        }
+
+        if(!InjectorUtils.isExitOptional(node.getCurrentTarget(), target)) {
+            throw CompatibilityHelper.makeInvalidInjectionException(this.info,
+                    String.format(
+                            "%s annotation is targeting a method exiting instruction that is not safe to remove in %s in %s",
+                            this.annotationType, target, this
+                    ));
+        }
+
+        InsnList insns = new InsnList();
+        if(!target.isStatic) {
+            insns.add(new VarInsnNode(Opcodes.ALOAD, 0));
+            if(hasParameter) {
+                insns.add(new InsnNode(Opcodes.SWAP));
+            }
+        }
+        AbstractInsnNode handler = this.invokeHandler(insns);
+        target.replaceNode(node.getCurrentTarget(), handler, insns);
+    }
+
+    protected boolean preInject(InjectionNode node) {
+        Meta other = node.getDecoration(Meta.KEY);
+        if (other.getOwner() != this) {
+            CompatibilityHelper.injectorLoggerWarn("{} conflict. Skipping {} with priority {}, already redirected by {} with priority {}",
+                    this.annotationType, this.info, this.meta.priority, other.name, other.priority);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/llamalad7/mixinextras/injector/WrapWithConditionInjector.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/WrapWithConditionInjector.java
@@ -42,7 +42,7 @@ public class WrapWithConditionInjector extends Injector {
                             this.annotationType, target, this
                     ));
         }
-        if(InjectorUtils.exitsMethod(node.getCurrentTarget()) && !InjectorUtils.isExitOptional(node.getCurrentTarget(), target.getArgIndices())) {
+        if(InjectorUtils.exitsMethod(node.getCurrentTarget()) && !InjectorUtils.isExitOptional(node.getCurrentTarget(), target)) {
             throw CompatibilityHelper.makeInvalidInjectionException(this.info,
                     String.format(
                             "%s annotation is targeting a method exiting instruction that is not safe to remove in %s in %s",

--- a/src/main/java/com/llamalad7/mixinextras/injector/WrapWithConditionInjector.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/WrapWithConditionInjector.java
@@ -42,7 +42,7 @@ public class WrapWithConditionInjector extends Injector {
                             this.annotationType, target, this
                     ));
         }
-        if(InjectorUtils.exitsMethod(node.getCurrentTarget()) && !InjectorUtils.isExitOptional(node.getCurrentTarget(), target.arguments.length)) {
+        if(InjectorUtils.exitsMethod(node.getCurrentTarget()) && !InjectorUtils.isExitOptional(node.getCurrentTarget(), target.getArgIndices())) {
             throw CompatibilityHelper.makeInvalidInjectionException(this.info,
                     String.format(
                             "%s annotation is targeting a method exiting instruction that is not safe to remove in %s in %s",

--- a/src/main/java/com/llamalad7/mixinextras/injector/WrapWithConditionInjector.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/WrapWithConditionInjector.java
@@ -130,21 +130,12 @@ public class WrapWithConditionInjector extends Injector {
             return new Type[]{Type.getType(Throwable.class)};
         }
         if(node.getOpcode() >= Opcodes.IRETURN && node.getOpcode() <= Opcodes.RETURN) {
-            switch(node.getOpcode()) {
-                case Opcodes.IRETURN:
-                    return new Type[]{Type.INT_TYPE};
-                case Opcodes.LRETURN:
-                    return new Type[]{Type.LONG_TYPE};
-                case Opcodes.FRETURN:
-                    return new Type[]{Type.FLOAT_TYPE};
-                case Opcodes.DRETURN:
-                    return new Type[]{Type.DOUBLE_TYPE};
-                case Opcodes.ARETURN:
-                    return new Type[]{target.returnType};
-                case Opcodes.RETURN:
-                    return new Type[]{};
-
+            if(node.getOpcode() == Opcodes.RETURN) {
+                return new Type[]{ };
             }
+
+            // We can use the return type of the target method
+            return new Type[]{target.returnType};
         }
 
         throw new UnsupportedOperationException();

--- a/src/main/java/com/llamalad7/mixinextras/point/BeforeThrow.java
+++ b/src/main/java/com/llamalad7/mixinextras/point/BeforeThrow.java
@@ -1,4 +1,4 @@
-package com.llamalad7.mixinextras.injector;
+package com.llamalad7.mixinextras.point;
 
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;

--- a/src/main/java/com/llamalad7/mixinextras/utils/CompatibilityHelper.java
+++ b/src/main/java/com/llamalad7/mixinextras/utils/CompatibilityHelper.java
@@ -1,12 +1,24 @@
 package com.llamalad7.mixinextras.utils;
 
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.spongepowered.asm.mixin.injection.InjectionPoint;
+import org.spongepowered.asm.mixin.injection.code.Injector;
+import org.spongepowered.asm.mixin.injection.modify.LocalVariableDiscriminator;
+import org.spongepowered.asm.mixin.injection.modify.ModifyVariableInjector;
 import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
+import org.spongepowered.asm.mixin.injection.struct.Target;
 import org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException;
 import org.spongepowered.asm.mixin.refmap.IMixinContext;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.security.InvalidParameterException;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
 
 /**
  * Helpers for writing code that is compatible with all variants of Mixin 0.8+
@@ -15,6 +27,12 @@ import java.util.Arrays;
 public class CompatibilityHelper {
     private static final Constructor<InvalidInjectionException> INVALID_INJECTION_EXCEPTION_CONSTRUCTOR;
     private static final Method INJECTION_INFO_GET_MIXIN_METHOD;
+    private static final Class<? extends  LocalVariableDiscriminator.Context> MODIFY_VARIABLE_CONTEXT_CLASS;
+    private static final Field MODIFY_VARIABLE_CONTEXT_INSNS;
+    private static final Constructor<LocalVariableDiscriminator.Context> MODIFY_VARIABLE_CONTEXT_CONSTRUCTOR;
+    private static final Method INJECTION_POINT_REGISTER_METHOD;
+    private static final Field INJECTOR_LOGGER;
+    private static final Method INJECTOR_LOGGER_WARN;
 
     static {
         INVALID_INJECTION_EXCEPTION_CONSTRUCTOR =
@@ -26,11 +44,90 @@ public class CompatibilityHelper {
                         .findAny()
                         .orElse(null);
 
+        MODIFY_VARIABLE_CONTEXT_CLASS =
+                (Class<? extends LocalVariableDiscriminator.Context>) Arrays.stream(ModifyVariableInjector.class.getDeclaredClasses())
+                        .filter(LocalVariableDiscriminator.Context.class::isAssignableFrom)
+                        .findAny()
+                        .orElse(null);
+
+        MODIFY_VARIABLE_CONTEXT_CONSTRUCTOR =
+                (Constructor<LocalVariableDiscriminator.Context>) Optional.ofNullable(MODIFY_VARIABLE_CONTEXT_CLASS).flatMap(
+                            context -> Arrays.stream(context.getConstructors())
+                                    .filter(it -> {
+                                        Class<?>[] parameters = it.getParameterTypes();
+                                        int length = parameters.length;
+                                        if (length != 4 && length != 5
+                                                || length == 5 && !parameters[0].isAssignableFrom(InjectionInfo.class)) {
+                                            return false;
+                                        }
+                                        return parameters[length - 4].isAssignableFrom(Type.class) && parameters[length - 3].isAssignableFrom(Boolean.TYPE) && parameters[length - 2].isAssignableFrom(Target.class) && parameters[length - 1].isAssignableFrom(AbstractInsnNode.class);
+                                    })
+                                    .findAny()
+                                    .map(it -> {
+                                        it.setAccessible(true);
+                                        return it;
+                                    })
+                        )
+                        .orElse(null);
+
         INJECTION_INFO_GET_MIXIN_METHOD =
                 Arrays.stream(InjectionInfo.class.getMethods())
                         .filter(it -> it.getParameterTypes().length == 0 && it.getReturnType() == IMixinContext.class && it.getName().startsWith("get"))
                         .findAny()
                         .orElse(null);
+
+        MODIFY_VARIABLE_CONTEXT_INSNS =
+                Optional.ofNullable(MODIFY_VARIABLE_CONTEXT_CLASS).flatMap(
+                        context -> Arrays.stream(context.getDeclaredFields())
+                                .filter(it -> it.getName().equals("insns") && InsnList.class.isAssignableFrom(it.getType()))
+                                .findAny()
+                        )
+                        .map(it -> {
+                            it.setAccessible(true);
+                            return it;
+                        })
+                        .orElse(null);
+
+        INJECTION_POINT_REGISTER_METHOD =
+                Arrays.stream(InjectionPoint.class.getMethods())
+                        .filter(it -> {
+                            if(!it.getName().equals("register")) {
+                                return false;
+                            }
+                            Class<?>[] parameters = it.getParameterTypes();
+                            int length = parameters.length;
+                            if (length != 1 && length != 2
+                                    || length == 2 && !parameters[1].isAssignableFrom(String.class)) {
+                                return false;
+                            }
+                            return parameters[0].isAssignableFrom(Class.class);
+                        })
+                        .max(Comparator.comparingInt(Method::getParameterCount))
+                        .orElse(null);
+
+        INJECTOR_LOGGER =
+                Arrays.stream(Injector.class.getDeclaredFields())
+                        .filter(it -> it.getName().equals("logger")) // We don't know the type of the logger
+                        .findAny()
+                        .map(it -> {
+                            it.setAccessible(true);
+                            return it;
+                        })
+                        .orElse(null);
+
+        INJECTOR_LOGGER_WARN =
+                Optional.ofNullable(INJECTOR_LOGGER).flatMap(logger ->
+                        Arrays.stream(logger.getType().getMethods())
+                                .filter(it -> {
+                                    if(it.getName().equals("warn")) {
+                                        return false;
+                                    }
+                                    Class<?>[] parameters = it.getParameterTypes();
+                                    return parameters.length == 2 && parameters[0].isAssignableFrom(String.class) && parameters[1].isAssignableFrom(Object[].class);
+                                })
+                                .findAny())
+                        .orElse(null);
+
     }
 
     public static RuntimeException makeInvalidInjectionException(InjectionInfo info, String message) {
@@ -44,6 +141,50 @@ public class CompatibilityHelper {
     public static IMixinContext getMixin(InjectionInfo info) {
         try {
             return (IMixinContext) INJECTION_INFO_GET_MIXIN_METHOD.invoke(info);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static LocalVariableDiscriminator.Context createModifyVariableContext(InjectionInfo info, Type returnType, Boolean argsOnly, Target target, AbstractInsnNode node) {
+        try {
+            if(MODIFY_VARIABLE_CONTEXT_CONSTRUCTOR.getParameterCount() == 4) {
+                return MODIFY_VARIABLE_CONTEXT_CONSTRUCTOR.newInstance(returnType, argsOnly, target, node);
+            }
+            return MODIFY_VARIABLE_CONTEXT_CONSTRUCTOR.newInstance(info, returnType, argsOnly, target, node);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static InsnList getModifyVariableContextInsns(LocalVariableDiscriminator.Context context) {
+        try {
+            if(!MODIFY_VARIABLE_CONTEXT_CLASS.isInstance(context)) {
+                throw new InvalidParameterException("'context' parameter wasn't of type 'ModifyVariableInjector.Context'");
+            }
+            return (InsnList) MODIFY_VARIABLE_CONTEXT_INSNS.get(context);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void registerInjectionPoint(Class<? extends InjectionPoint> type, String namespace, Class<? extends InjectionPoint> namespacedType) {
+        try {
+            if(INJECTION_POINT_REGISTER_METHOD.getParameterCount() == 2) {
+                INJECTION_POINT_REGISTER_METHOD.invoke(null, type, namespace);
+                return;
+            }
+
+            // If Mixin doesn't support namespaces, we use a type that has the namespace specified in the annotation
+            INJECTION_POINT_REGISTER_METHOD.invoke(null, namespacedType);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void injectorLoggerWarn(String message, Object ... args) {
+        try {
+            INJECTOR_LOGGER_WARN.invoke(INJECTOR_LOGGER.get(null), message, args);
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/llamalad7/mixinextras/utils/InjectorUtils.java
+++ b/src/main/java/com/llamalad7/mixinextras/utils/InjectorUtils.java
@@ -21,13 +21,15 @@ public class InjectorUtils {
      * in all paths following the node are initialized. If that is case, the node can be removed or
      * conditionally surpassed and the method will still have valid bytecode, making the exit optional.
      */
-    public static boolean isExitOptional(AbstractInsnNode node, int methodArgumentCount) {
+    public static boolean isExitOptional(AbstractInsnNode node, int[] argIndices) {
         Set<Integer> unassignedVariables = new HashSet<>();
         Set<Integer> assignedVariables = new HashSet<>();
-        // We add already initialized method parameters and 'this'
-        for(int i = 0; i <= methodArgumentCount; i++) {
-            assignedVariables.add(i);
+
+        for(int i = 0; i < argIndices.length; i++) {
+            assignedVariables.add(argIndices[i]);
         }
+        assignedVariables.add(0);
+
         boolean exits = checkAllFollowingPathsExitingAndFindLocals(node, new HashSet<>(64), true, false, assignedVariables, unassignedVariables);
         if(!exits || unassignedVariables.size() == 0) {
             return exits;

--- a/src/main/java/com/llamalad7/mixinextras/utils/InjectorUtils.java
+++ b/src/main/java/com/llamalad7/mixinextras/utils/InjectorUtils.java
@@ -1,10 +1,297 @@
 package com.llamalad7.mixinextras.utils;
 
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
 import org.spongepowered.asm.mixin.injection.struct.InjectionNodes;
+
+import java.util.*;
+import java.util.stream.Stream;
 
 public class InjectorUtils {
     public static boolean isVirtualRedirect(InjectionNodes.InjectionNode node) {
         return node.isReplaced() && node.hasDecoration("redirector") && node.getCurrentTarget().getOpcode() != Opcodes.INVOKESTATIC;
+    }
+
+    public static boolean exitsMethod(AbstractInsnNode node) {
+        return node.getOpcode() >= Opcodes.IRETURN && node.getOpcode() <= Opcodes.RETURN || node.getOpcode() == Opcodes.ATHROW;
+    }
+
+    /**
+     * Checks whether all paths following the node exit the method and whether all loaded variables
+     * in all paths following the node are initialized. If that is case, the node can be removed or
+     * conditionally surpassed and the method will still have valid bytecode, making the exit optional.
+     */
+    public static boolean isExitOptional(AbstractInsnNode node, int methodArgumentCount) {
+        Set<Integer> unassignedVariables = new HashSet<>();
+        Set<Integer> assignedVariables = new HashSet<>();
+        // We add already initialized method parameters and 'this'
+        for(int i = 0; i <= methodArgumentCount; i++) {
+            assignedVariables.add(i);
+        }
+        boolean exits = checkAllFollowingPathsExitingAndFindLocals(node, new HashSet<>(64), true, false, assignedVariables, unassignedVariables);
+        if(!exits || unassignedVariables.size() == 0) {
+            return exits;
+        }
+        // We have to check whether all variables in unassignedVariables are assigned in all paths leading up to the node
+        return areVariablesInitialized(node, unassignedVariables);
+    }
+
+    /**
+     * Checks whether all paths following the node exit the method, adds all variables, that are assigned in the paths
+     * following the node, to {@code assignedVariables} and adds all variables that are used but not assigned to {@code unassignedVariables}
+     * @param node The method exiting node to check
+     * @param visitedNodes All nodes already visited by this method that don't have to be visited again
+     * @param defaultWhenAlreadyVisited The value this method should return upon reaching an already visited node
+     * @param stopAtRet Whether this method should stop upon reaching {@link Opcodes#RET} and return false.
+     * @param assignedVariables Set to add all variables to, that are assigned in the immediate path following the node.
+     *                          Variables that are only assigned in any conditional branches are not added
+     * @param unassignedVariables Set to add all variables to, that are used but not previously assigned in the paths following the node
+     */
+    private static boolean checkAllFollowingPathsExitingAndFindLocals(
+            AbstractInsnNode node,
+            HashSet<AbstractInsnNode> visitedNodes,
+            boolean defaultWhenAlreadyVisited,
+            boolean stopAtRet,
+            Set<Integer> assignedVariables,
+            Set<Integer> unassignedVariables) {
+        if(!visitedNodes.add(node)) {
+            return defaultWhenAlreadyVisited;
+        }
+        node = node.getNext();
+        if(node == null) {
+            return false;
+        }
+        while(!exitsMethod(node)) {
+            if(!visitedNodes.add(node)) {
+                return defaultWhenAlreadyVisited;
+            }
+            if(stopAtRet && node.getOpcode() == Opcodes.RET) {
+                return false;
+            }
+            if(node instanceof JumpInsnNode) {
+                JumpInsnNode jumpInsnNode = (JumpInsnNode) node;
+                if(jumpInsnNode.getOpcode() == Opcodes.GOTO) {
+                    node = jumpInsnNode.label;
+                    if(!visitedNodes.add(node)) {
+                        return defaultWhenAlreadyVisited;
+                    }
+                } else if(jumpInsnNode.getOpcode() == Opcodes.JSR) {
+                    if(checkAllFollowingPathsExitingAndFindLocals(jumpInsnNode.label, visitedNodes, false, true, assignedVariables, unassignedVariables)) {
+                        return true; // We know that the subroutine always exits
+                    }
+                } else if(!checkAllFollowingPathsExitingAndFindLocals(jumpInsnNode.label, visitedNodes, true, stopAtRet, assignedVariables, new HashSet<>(unassignedVariables))) {
+                    return false; // We know that the conditional jump doesn't always return
+                }
+            } else if(node instanceof TableSwitchInsnNode) {
+                TableSwitchInsnNode tableSwitchInsnNode = (TableSwitchInsnNode) node;
+                for(LabelNode labelNode : tableSwitchInsnNode.labels) {
+                    if (!checkAllFollowingPathsExitingAndFindLocals(labelNode, visitedNodes, true, stopAtRet, assignedVariables, new HashSet<>(unassignedVariables))) {
+                        return false;
+                    }
+                }
+                return checkAllFollowingPathsExitingAndFindLocals(tableSwitchInsnNode.dflt, visitedNodes, true, stopAtRet, assignedVariables, new HashSet<>(unassignedVariables));
+            } else if(node instanceof LookupSwitchInsnNode) {
+                LookupSwitchInsnNode lookupSwitchInsnNode = (LookupSwitchInsnNode) node;
+                for(LabelNode labelNode : lookupSwitchInsnNode.labels) {
+                    if (!checkAllFollowingPathsExitingAndFindLocals(labelNode, visitedNodes, true, stopAtRet, assignedVariables, new HashSet<>(unassignedVariables))) {
+                        return false;
+                    }
+                }
+                return checkAllFollowingPathsExitingAndFindLocals(lookupSwitchInsnNode.dflt, visitedNodes, true, stopAtRet, assignedVariables, new HashSet<>(unassignedVariables));
+            } else if(node instanceof VarInsnNode) {
+                int var = ((VarInsnNode) node).var;
+                if(node.getOpcode() >= Opcodes.ISTORE && node.getOpcode() <= Opcodes.ASTORE) {
+                    assignedVariables.add(var);
+                } else if(node.getOpcode() >= Opcodes.ILOAD && node.getOpcode() <= Opcodes.ALOAD && !assignedVariables.contains(var)) {
+                    unassignedVariables.add(var);
+                }
+            }
+            node = node.getNext();
+            if(node == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Creates a set consisting of all {@link JumpInsnNode}s, {@link LookupSwitchInsnNode}s and {@link TableSwitchInsnNode}s that jump to the specified target and
+     * come after the given node or are the given node. The nodes can thus be reached through
+     * {@link AbstractInsnNode#getNext()}
+     * @param node The node to get all other nodes from using {@link AbstractInsnNode#getNext()}
+     * @param target The label that the returned {@link JumpInsnNode}s should target
+     */
+    public static Set<AbstractInsnNode> getAllTargetingNodes(AbstractInsnNode node, LabelNode target) {
+
+        // We don't need to create a new instance when no matching nodes are found
+        Set<AbstractInsnNode> set = Collections.emptySet();
+
+        while(node != null) {
+            boolean isJumpingToTarget = false;
+            if(node instanceof JumpInsnNode) {
+                JumpInsnNode jumpInsnNode = (JumpInsnNode) node;
+                isJumpingToTarget = jumpInsnNode.label == target;
+            } else if(node instanceof TableSwitchInsnNode) {
+                TableSwitchInsnNode tableSwitchInsnNode = (TableSwitchInsnNode) node;
+                isJumpingToTarget = tableSwitchInsnNode.dflt == target || tableSwitchInsnNode.labels.contains(target);
+            } else if(node instanceof LookupSwitchInsnNode) {
+                LookupSwitchInsnNode lookupSwitchInsnNode = (LookupSwitchInsnNode) node;
+                isJumpingToTarget = lookupSwitchInsnNode.dflt == target || lookupSwitchInsnNode.labels.contains(target);
+            }
+            if(isJumpingToTarget) {
+                if(set.isEmpty()) {
+                    set = new HashSet<>();
+                }
+                set.add(node);
+            }
+            node = node.getNext();
+        }
+        return set;
+    }
+
+    /**
+     * Checks whether all given variables are initialized at the given node for every path that leads to the given node
+     * @param node The node to check at
+     * @param variables The variables to check for whether they are initialized. If variables are initialized
+     *                  before the given node without jumps, they are removed from the set.
+     * @return Whether all given variables are initialized
+     */
+    public static boolean areVariablesInitialized(AbstractInsnNode node, Set<Integer> variables) {
+
+        // Find the first node to use in getAllTargetingNodes
+        AbstractInsnNode first = node;
+        while(first.getPrevious() != null) {
+            first = first.getPrevious();
+        }
+
+        while(true) {
+            if(node instanceof VarInsnNode) {
+                if(node.getOpcode() >= Opcodes.ISTORE && node.getOpcode() <= Opcodes.ASTORE) {
+                    VarInsnNode varInsnNode = (VarInsnNode) node;
+                    variables.remove(varInsnNode.var);
+                    if(variables.isEmpty()) {
+                        return true;
+                    }
+                }
+            } else if(node instanceof LabelNode) {
+                LabelNode labelNode = (LabelNode) node;
+                Set<AbstractInsnNode> targetingNodes = getAllTargetingNodes(first, labelNode);
+                for(AbstractInsnNode targetingNode : targetingNodes) {
+                    if(!areVariablesInitialized(targetingNode, new HashSet<>(variables))) {
+                        return false;
+                    }
+                }
+            } else if(node instanceof JumpInsnNode && node.getOpcode() == Opcodes.JSR) {
+                variables = removeSubroutineAssignedVariables(((JumpInsnNode) node).label, new HashSet<>(variables));
+                if(
+                        variables == null
+                        // We know that the subroutine always returns and
+                        // that the current code will thus only be reached by
+                        // jumps, which we already checked
+
+                        || variables.isEmpty()
+                        // We know that all variables left are initialized in the subroutine
+                ) {
+                    return true;
+                }
+            }
+
+            node = node.getPrevious();
+            if(node == null) {
+                return false;
+            }
+            if(exitsMethod(node) || node instanceof JumpInsnNode && node.getOpcode() == Opcodes.GOTO) {
+                // We know that the instruction won't continue to the
+                // next instruction and that the current code will
+                // thus only be reached by jumps, which we already checked
+                return true;
+            }
+        }
+    }
+
+    /**
+     * Returns a set of all variables from the given set that aren't always set in the
+     * subroutine beginning at the given node. Variables that are set before any conditional jump,
+     * will also be removed from the given set. If all paths lead to any RETURN instruction or end
+     * at the end of the method (meaning there is no next node), {@code null} is returned
+     * @param node The node in a subroutine to start at
+     * @param variables A set of variables that will be checked for whether they are set in
+     *                  the subroutine
+     * @return The set of all variables from the given set that aren't always set in the subroutine
+     */
+    public static Set<Integer> removeSubroutineAssignedVariables(AbstractInsnNode node, Set<Integer> variables) {
+        while(node != null) {
+            if(exitsMethod(node)) {
+                return null;
+            }
+            if(node.getOpcode() == Opcodes.RET) {
+                return variables;
+            }
+            if(node instanceof VarInsnNode) {
+                if(node.getOpcode() >= Opcodes.ISTORE && node.getOpcode() <= Opcodes.ASTORE) {
+                    VarInsnNode varInsnNode = (VarInsnNode) node;
+                    variables.remove(varInsnNode.var);
+                }
+            } else if(node instanceof JumpInsnNode) {
+                JumpInsnNode jumpInsnNode = (JumpInsnNode) node;
+                if(jumpInsnNode.getOpcode() == Opcodes.GOTO) {
+                    node = jumpInsnNode.label;
+                } else if(jumpInsnNode.getOpcode() == Opcodes.JSR) {
+                    variables = removeSubroutineAssignedVariables(jumpInsnNode.label, variables);
+                    if(variables == null) {
+                        // We know that the nested subroutine always returns, so
+                        // the current subroutine branch also does
+                        return null;
+                    }
+                } else {
+                    Set<Integer> first = removeSubroutineAssignedVariables(node.getNext(), new HashSet<>(variables));
+                    Set<Integer> second = removeSubroutineAssignedVariables(jumpInsnNode.label, new HashSet<>(variables));
+                    if(first == null) {
+                        return second;
+                    }
+                    if(second == null) {
+                        return first;
+                    }
+                    first.addAll(second);
+                    return first;
+                }
+            } else if(node instanceof TableSwitchInsnNode) {
+                TableSwitchInsnNode tableSwitchInsnNode = (TableSwitchInsnNode) node;
+                Set<Integer> finalVariables = variables;
+                return Stream.concat(tableSwitchInsnNode.labels.stream(), Stream.of(tableSwitchInsnNode.dflt))
+                        .map(label -> removeSubroutineAssignedVariables(label, new HashSet<>(finalVariables)))
+                        .reduce(null, (first, second) -> {
+                            if(first == null) {
+                                return second;
+                            }
+                            if(second == null) {
+                                return first;
+                            }
+                            first.addAll(second);
+                            return first;
+                        });
+            } else if(node instanceof LookupSwitchInsnNode) {
+                LookupSwitchInsnNode tableSwitchInsnNode = (LookupSwitchInsnNode) node;
+                Set<Integer> finalVariables = variables;
+                return Stream.concat(tableSwitchInsnNode.labels.stream(), Stream.of(tableSwitchInsnNode.dflt))
+                        .map(label -> removeSubroutineAssignedVariables(label, new HashSet<>(finalVariables)))
+                        .reduce(null, (first, second) -> {
+                            if(first == null) {
+                                return second;
+                            }
+                            if(second == null) {
+                                return first;
+                            }
+                            first.addAll(second);
+                            return first;
+                        });
+            }
+
+            node = node.getNext();
+        }
+
+        // Should never happen with valid bytecode, but we return null,
+        // because no RET instruction was reached
+        return null;
     }
 }


### PR DESCRIPTION
- `@WrapWithCondition` is now able to wrap method exiting instructions, if they are safe to remove. Method exiting instructions are safe to remove, if they're always followed by another method exiting instruction and all variables, that are later used and not set, are initialized.
- Added the `@InitVariable` injector, which can set variables, but, unlike `@ModifyVariable`, it doesn't provide the previous value and only variables from the next frame instead of the current frame are available.
- Added the `BeforeThrow` (`@At("MIXINEXTRAS:THROW")`) injection point that targets `ATHROW` instructions and also can optionally accept an ordinal.
- Added `@RedirectExit` injector, which can replace `ATHROW` and return instructions.
- Changed `@ModifyReturnValue` to support replacement of the target instruction by checking the opcode of the original target instead of the current target
- Added `@ModifyThrowValue` to change `Throwable`s about to be thrown.

Methods for the required bytecode validation are in `InjectorUtils`.
My fork contains possible wiki entries representing the changes.
