### PR TITLE
Mark the fabric version as a library in Mod Menu

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -18,5 +18,10 @@
   ],
   "depends": {
     "fabricloader": ">=0.14.11"
+  },
+  "custom": {
+    "modmenu": {
+      "badges": [ "library" ]
+    }
   }
 }


### PR DESCRIPTION
This hides it from the end user when libraries are hidden (default) and adds a badge otherwise.