### PR TITLE
Add memberExists and typeExists to IdentifierPool

### DIFF
--- a/src/main/java/com/llamalad7/mixinextras/expression/impl/pool/IdentifierPool.java
+++ b/src/main/java/com/llamalad7/mixinextras/expression/impl/pool/IdentifierPool.java
@@ -70,4 +70,12 @@ public class IdentifierPool {
     public void addType(String id, TypeDefinition entry) {
         types.computeIfAbsent(id, k -> new ArrayList<>()).add(entry);
     }
+
+    public boolean memberExists(String id) {
+        return members.containsKey(id);
+    }
+
+    public boolean typeExists(String id) {
+        return types.containsKey(id);
+    }
 }


### PR DESCRIPTION
This is to allow for mcdev to replace unknown identifiers with `?` for auto-completion