### PR TITLE
Generalize `allowIncompleteMethodArgs` to `allowIncompleteListInputs`

### DIFF
--- a/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/ArrayLiteralExpression.java
+++ b/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/ArrayLiteralExpression.java
@@ -39,10 +39,10 @@ public class ArrayLiteralExpression extends SimpleExpression {
     }
 
     private boolean valuesMatch(List<FlowValue> flows, ExpressionContext ctx) {
-        if (flows.size() != values.size()) {
+        if (!(ctx.allowIncompleteListInputs && values.size() < flows.size()) && flows.size() != values.size()) {
             return false;
         }
-        for (int i = 0; i < flows.size(); i++) {
+        for (int i = 0; i < values.size(); i++) {
             if (!values.get(i).matches(flows.get(i), ctx)) {
                 return false;
             }

--- a/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/InstantiationExpression.java
+++ b/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/InstantiationExpression.java
@@ -41,7 +41,7 @@ public class InstantiationExpression extends Expression {
                     nextInsn.getOpcode() == Opcodes.INVOKESPECIAL
                             && ((MethodInsnNode) nextInsn).name.equals("<init>")
                             && nextValue.getInput(0) == node
-                            && inputsMatch(1, nextValue, ctx, ctx.allowIncompleteMethodArgs, arguments.toArray(new Expression[0]))
+                            && inputsMatch(1, nextValue, ctx, ctx.allowIncompleteListInputs, arguments.toArray(new Expression[0]))
             ) {
                 return true;
             }

--- a/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/MethodCallExpression.java
+++ b/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/MethodCallExpression.java
@@ -36,7 +36,7 @@ public class MethodCallExpression extends SimpleExpression {
                     return false;
                 }
                 Expression[] inputs = ArrayUtils.add(arguments.toArray(new Expression[0]), 0, receiver);
-                return inputsMatch(node, ctx, ctx.allowIncompleteMethodArgs, inputs);
+                return inputsMatch(node, ctx, ctx.allowIncompleteListInputs, inputs);
         }
         return false;
     }

--- a/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/NewArrayExpression.java
+++ b/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/NewArrayExpression.java
@@ -38,13 +38,13 @@ public class NewArrayExpression extends SimpleExpression {
             return false;
         }
         int newBlankDims = getBlankDims(node.getInsn());
-        if (blankDims != newBlankDims) {
+        if (newBlankDims + node.inputCount() < blankDims + dims.size()) {
             return false;
         }
         if (!innerType.matches(ctx.pool, newInnerType)) {
             return false;
         }
-        return inputsMatch(node, ctx, dims.toArray(new Expression[0]));
+        return inputsMatch(node, ctx, ctx.allowIncompleteListInputs, dims.toArray(new Expression[0]));
     }
 
     private Type getInnerType(AbstractInsnNode insn) {

--- a/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/StaticMethodCallExpression.java
+++ b/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/StaticMethodCallExpression.java
@@ -23,6 +23,7 @@ public class StaticMethodCallExpression extends SimpleExpression {
     public boolean matches(FlowValue node, ExpressionContext ctx) {
         AbstractInsnNode insn = node.getInsn();
         return insn.getOpcode() == Opcodes.INVOKESTATIC
-                && name.matches(ctx.pool, insn) && inputsMatch(node, ctx, arguments.toArray(new Expression[0]));
+                && name.matches(ctx.pool, insn)
+                && inputsMatch(node, ctx, ctx.allowIncompleteListInputs, arguments.toArray(new Expression[0]));
     }
 }

--- a/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/SuperCallExpression.java
+++ b/src/main/java/com/llamalad7/mixinextras/expression/impl/ast/expressions/SuperCallExpression.java
@@ -31,6 +31,6 @@ public class SuperCallExpression extends SimpleExpression {
         if (!name.matches(ctx.pool, node.getInsn())) {
             return false;
         }
-        return new ThisExpression(null).matches(node.getInput(0), ctx) && inputsMatch(1, node, ctx, arguments.toArray(new Expression[0]));
+        return new ThisExpression(null).matches(node.getInput(0), ctx) && inputsMatch(1, node, ctx, ctx.allowIncompleteListInputs, arguments.toArray(new Expression[0]));
     }
 }

--- a/src/main/java/com/llamalad7/mixinextras/expression/impl/point/ExpressionContext.java
+++ b/src/main/java/com/llamalad7/mixinextras/expression/impl/point/ExpressionContext.java
@@ -12,14 +12,14 @@ public class ExpressionContext {
     public final ClassNode classNode;
     public final MethodNode method;
     public final boolean isStatic;
-    public final boolean allowIncompleteMethodArgs;
+    public final boolean allowIncompleteListInputs;
 
-    public ExpressionContext(IdentifierPool pool, Expression.OutputSink sink, ClassNode classNode, MethodNode method, boolean allowIncompleteMethodArgs) {
+    public ExpressionContext(IdentifierPool pool, Expression.OutputSink sink, ClassNode classNode, MethodNode method, boolean allowIncompleteListInputs) {
         this.pool = pool;
         this.sink = sink;
         this.classNode = classNode;
         this.method = method;
         this.isStatic = (method.access & Opcodes.ACC_STATIC) != 0;
-        this.allowIncompleteMethodArgs = allowIncompleteMethodArgs;
+        this.allowIncompleteListInputs = allowIncompleteListInputs;
     }
 }


### PR DESCRIPTION
This PR generalizes the previous `allowIncompleteMethodArgs` and introduces the concept of "list inputs". A list input is any time an expression expects a variable number of inputs, typically (but not always) separated by commas. It does *not* include fixed inputs, such as the inputs to a binary operator.

A list of list inputs:
- Method arguments for all types of method call expression. A couple of these were missing `allowIncompleteMethodArgs` last time so I added them.
- The initializer list in array literals.
- The dimensions inside of a new array expression. This is perhaps the most controversial of the list, we can discuss whether this is a good idea.