### PR TITLE
Allow omitting parameters in WrapMethod handler

### DIFF
--- a/src/main/java/com/llamalad7/mixinextras/injector/wrapmethod/WrapMethodApplicatorExtension.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/wrapmethod/WrapMethodApplicatorExtension.java
@@ -14,10 +14,10 @@ import java.util.*;
 public class WrapMethodApplicatorExtension implements IExtension {
     private static final Map<ClassNode, Map<MethodNode, WrapMethodStage>> wrappers = new HashMap<>();
 
-    static void offerWrapper(Target target, MethodNode handler, Type operationType, List<ShareInfo> shares) {
+    static void offerWrapper(Target target, MethodNode handler, Type operationType, List<ShareInfo> shares, boolean captureParams) {
         Map<MethodNode, WrapMethodStage> relevant = wrappers.computeIfAbsent(target.classNode, k -> new LinkedHashMap<>());
         WrapMethodStage inner = relevant.computeIfAbsent(target.method, WrapMethodStage.Vanilla::new);
-        relevant.put(target.method, new WrapMethodStage.Wrapper(inner, handler, operationType, shares));
+        relevant.put(target.method, new WrapMethodStage.Wrapper(inner, handler, operationType, shares, captureParams));
     }
 
     @Override

--- a/src/main/java/com/llamalad7/mixinextras/injector/wrapmethod/WrapMethodInjector.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/wrapmethod/WrapMethodInjector.java
@@ -50,7 +50,7 @@ public class WrapMethodInjector extends Injector {
         handler.coerceReturnType = checkCoerce(-1, target.returnType, description, true);
 
         int argIndex = 0;
-        for (; argIndex < target.arguments.length; argIndex++) {
+        for (; captureParams && argIndex < target.arguments.length; argIndex++) {
             Type theirType = target.arguments[argIndex];
             if (argIndex >= methodArgs.length) {
                 throw CompatibilityHelper.makeInvalidInjectionException(
@@ -64,9 +64,13 @@ public class WrapMethodInjector extends Injector {
             try {
                 checkCoerce(argIndex, theirType, description, true);
             } catch (InvalidInjectionException e) {
-                if (argIndex == 0 && methodArgs[argIndex].equals(operationType)) {
+                // recheck with captureParams disabled to see if params are omitted
+                // doing this ensures that any weird edge cases where an 'Operation'
+                // is part of the params are handled correctly
+                if (methodArgs[0].equals(operationType)) {
                     captureParams = false;
-                    break;
+                    this.checkSignature(target);
+                    return;
                 }
                 throw e;
             }

--- a/src/main/java/com/llamalad7/mixinextras/injector/wrapmethod/WrapMethodInjector.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/wrapmethod/WrapMethodInjector.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.code.Injector;
 import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
 import org.spongepowered.asm.mixin.injection.struct.InjectionNodes.InjectionNode;
 import org.spongepowered.asm.mixin.injection.struct.Target;
+import org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException;
 import org.spongepowered.asm.util.Annotations;
 
 import java.util.ArrayList;
@@ -18,6 +19,7 @@ import java.util.List;
 public class WrapMethodInjector extends Injector {
     private final Type operationType = MixinExtrasService.getInstance().changePackage(Operation.class, Type.getType(CompatibilityHelper.getAnnotation(info).desc), WrapMethod.class);
     private final List<ShareInfo> shares = new ArrayList<>();
+    private boolean captureParams = true;
 
     public WrapMethodInjector(InjectionInfo info) {
         super(info, "@WrapMethod");
@@ -28,7 +30,7 @@ public class WrapMethodInjector extends Injector {
         this.checkTargetModifiers(target, true);
         this.checkSignature(target);
         info.addCallbackInvocation(methodNode);
-        WrapMethodApplicatorExtension.offerWrapper(target, methodNode, operationType, shares);
+        WrapMethodApplicatorExtension.offerWrapper(target, methodNode, operationType, shares, captureParams);
     }
 
     private void checkSignature(Target target) {
@@ -59,7 +61,15 @@ public class WrapMethodInjector extends Injector {
                         )
                 );
             }
-            checkCoerce(argIndex, theirType, description, true);
+            try {
+                checkCoerce(argIndex, theirType, description, true);
+            } catch (InvalidInjectionException e) {
+                if (argIndex == 0 && methodArgs[argIndex].equals(operationType)) {
+                    captureParams = false;
+                    break;
+                }
+                throw e;
+            }
         }
         if (argIndex >= methodArgs.length || !methodArgs[argIndex++].equals(operationType)) {
             throw CompatibilityHelper.makeInvalidInjectionException(

--- a/src/main/java/com/llamalad7/mixinextras/injector/wrapmethod/WrapMethodInjector.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/wrapmethod/WrapMethodInjector.java
@@ -50,7 +50,7 @@ public class WrapMethodInjector extends Injector {
         handler.coerceReturnType = checkCoerce(-1, target.returnType, description, true);
 
         int argIndex = 0;
-        for (; captureParams && argIndex < target.arguments.length; argIndex++) {
+        for (; argIndex < target.arguments.length; argIndex++) {
             Type theirType = target.arguments[argIndex];
             if (argIndex >= methodArgs.length) {
                 throw CompatibilityHelper.makeInvalidInjectionException(
@@ -64,13 +64,12 @@ public class WrapMethodInjector extends Injector {
             try {
                 checkCoerce(argIndex, theirType, description, true);
             } catch (InvalidInjectionException e) {
-                // recheck with captureParams disabled to see if params are omitted
-                // doing this ensures that any weird edge cases where an 'Operation'
-                // is part of the params are handled correctly
+                // if the first parameter is an 'Operation',
+                // check from index 0 with param capture disabled
                 if (methodArgs[0].equals(operationType)) {
                     captureParams = false;
-                    this.checkSignature(target);
-                    return;
+                    argIndex = 0;
+                    break;
                 }
                 throw e;
             }

--- a/src/main/java/com/llamalad7/mixinextras/injector/wrapoperation/WrapOperationInjector.java
+++ b/src/main/java/com/llamalad7/mixinextras/injector/wrapoperation/WrapOperationInjector.java
@@ -125,7 +125,8 @@ class WrapOperationInjector extends Injector {
                     InsnList copied = new InsnList();
                     operation.copyNode(copied, paramArrayIndex, loadArgs, returnType);
                     return copied;
-                }
+                },
+                true
         );
     }
 


### PR DESCRIPTION
When wrapping many methods with the same logic without modifying their parameters (for example for synchronization), it would be useful to be able to omit specifiying parameters to be able to target many methods with differing parameters with a single handler.
This is similar to `@Inject` allowing params to be left out.

The behaviour works as follows:
If there is an exception when checking the target params and the first handler param is of type `Operation`, `captureParams` will be set to false.
If `captureParams` is false:
- Parameters are passed to lamba creation instead of the handler method
- The bridge method will be generated with bound parameters, then the method parameters, then `Object[]`
- The object array passed through `Operation#call` will be enforced to be empty
- The passed params are loaded instead of the array elements