### PR TITLE
Change mod type to LIBRARY, as opposed to GAMELIBRARY, on neoforge

### DIFF
--- a/platform/neoforge/build.gradle.kts
+++ b/platform/neoforge/build.gradle.kts
@@ -9,6 +9,7 @@ repositories {
 
 dependencies {
     compileOnly("net.neoforged.fancymodloader:language-java:1.0.2")
+    compileOnly("net.neoforged.fancymodloader:loader:1.0.2")
 }
 
 java {

--- a/platform/neoforge/build.gradle.kts
+++ b/platform/neoforge/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    maven("https://maven.neoforged.net/")
+    maven("https://maven.neoforged.net/releases/")
 }
 
 dependencies {

--- a/platform/neoforge/build.gradle.kts
+++ b/platform/neoforge/build.gradle.kts
@@ -22,7 +22,7 @@ java {
 jarsNamed("jar", "slimJar") {
     manifest.attributes(
         "MixinConfigs" to "mixinextras.init.mixins.json",
-        "FMLModType" to "GAMELIBRARY",
+        "FMLModType" to "LIBRARY",
         "Automatic-Module-Name" to "mixinextras.neoforge",
     )
 }

--- a/platform/neoforge/src/main/java/com/llamalad7/mixinextras/platform/neoforge/MixinExtrasConfigPlugin.java
+++ b/platform/neoforge/src/main/java/com/llamalad7/mixinextras/platform/neoforge/MixinExtrasConfigPlugin.java
@@ -1,6 +1,9 @@
 package com.llamalad7.mixinextras.platform.neoforge;
 
 import com.llamalad7.mixinextras.MixinExtrasBootstrap;
+import com.llamalad7.mixinextras.utils.ResourceUtils;
+import cpw.mods.modlauncher.Launcher;
+import cpw.mods.modlauncher.api.IModuleLayerManager;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
@@ -11,7 +14,25 @@ import java.util.Set;
 public class MixinExtrasConfigPlugin implements IMixinConfigPlugin {
     @Override
     public void onLoad(String mixinPackage) {
+        try {
+            Class.forName("cpw.mods.modlauncher.Launcher");
+            MixinExtrasBootstrap.init(new ModLauncherConfigsFinder());
+            return;
+        } catch (ClassNotFoundException ignored) {}
         MixinExtrasBootstrap.init();
+    }
+    
+    private static class ModLauncherConfigsFinder implements ResourceUtils.ConfigsFinder {
+        @Override
+        public ClassLoader getClassLoader() {
+            return Launcher.INSTANCE.findLayerManager()
+                    // Get the game layer
+                    .flatMap(layerManager -> layerManager.getLayer(IModuleLayerManager.Layer.GAME))
+                    // Get "minecraft" module or "neoforge" module off the game layer
+                    .flatMap(layer -> layer.findModule("minecraft").or(() -> layer.findModule("neoforge")))
+                    .map(Module::getClassLoader)
+                    .orElseThrow(() -> new IllegalStateException("Cannot find a ClassLoader for the game layer!"));
+        }
     }
 
     @Override

--- a/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
+++ b/src/main/java/com/llamalad7/mixinextras/MixinExtrasBootstrap.java
@@ -2,6 +2,7 @@ package com.llamalad7.mixinextras;
 
 import com.llamalad7.mixinextras.service.MixinExtrasService;
 import com.llamalad7.mixinextras.service.MixinExtrasVersion;
+import com.llamalad7.mixinextras.utils.ResourceUtils;
 
 @SuppressWarnings("unused")
 public class MixinExtrasBootstrap {
@@ -13,10 +14,14 @@ public class MixinExtrasBootstrap {
     }
 
     public static void init() {
+        init(ResourceUtils.ConfigsFinder.defaultConfigsFinder());
+    }
+    
+    public static void init(ResourceUtils.ConfigsFinder configsFinder) {
         if (initialized) {
             return;
         }
         initialized = true;
-        MixinExtrasService.setup();
+        MixinExtrasService.setup(configsFinder);
     }
 }

--- a/src/main/java/com/llamalad7/mixinextras/service/MixinExtrasService.java
+++ b/src/main/java/com/llamalad7/mixinextras/service/MixinExtrasService.java
@@ -2,6 +2,7 @@ package com.llamalad7.mixinextras.service;
 
 import com.llamalad7.mixinextras.utils.Blackboard;
 import com.llamalad7.mixinextras.utils.ProxyUtils;
+import com.llamalad7.mixinextras.utils.ResourceUtils;
 import org.spongepowered.asm.mixin.injection.InjectionPoint;
 import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
 import org.spongepowered.asm.mixin.transformer.ext.IExtension;
@@ -25,15 +26,15 @@ public interface MixinExtrasService {
 
     void initialize();
 
-    static void setup() {
+    static void setup(ResourceUtils.ConfigsFinder configsFinder) {
         Object latestImpl = Blackboard.get("MixinExtrasServiceInstance");
         if (latestImpl == null) {
-            MixinExtrasService newImpl = new MixinExtrasServiceImpl();
+            MixinExtrasService newImpl = new MixinExtrasServiceImpl(configsFinder);
             Blackboard.put("MixinExtrasServiceInstance", newImpl);
             newImpl.takeControlFrom(null);
             return;
         }
-        MixinExtrasService ourImpl = new MixinExtrasServiceImpl();
+        MixinExtrasService ourImpl = new MixinExtrasServiceImpl(configsFinder);
         if (ourImpl.shouldReplace(latestImpl)) {
             getFrom(latestImpl).concedeTo(ourImpl, true);
             Blackboard.put("MixinExtrasServiceInstance", ourImpl);

--- a/src/main/java/com/llamalad7/mixinextras/service/MixinExtrasServiceImpl.java
+++ b/src/main/java/com/llamalad7/mixinextras/service/MixinExtrasServiceImpl.java
@@ -12,6 +12,7 @@ import com.llamalad7.mixinextras.sugar.impl.SugarWrapperInjectionInfo;
 import com.llamalad7.mixinextras.transformer.MixinTransformerExtension;
 import com.llamalad7.mixinextras.utils.MixinExtrasLogger;
 import com.llamalad7.mixinextras.utils.MixinInternals;
+import com.llamalad7.mixinextras.utils.ResourceUtils;
 import com.llamalad7.mixinextras.wrapper.factory.FactoryRedirectWrapperInjectionInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.objectweb.asm.Type;
@@ -55,8 +56,13 @@ public class MixinExtrasServiceImpl implements MixinExtrasService {
             ExpressionInjectorWrapperInjectionInfo.class
     );
     private final List<String> registeredInjectors = new ArrayList<>();
+    private final ResourceUtils.ConfigsFinder mixinConfigsFinder;
 
     boolean initialized;
+
+    public MixinExtrasServiceImpl(ResourceUtils.ConfigsFinder mixinConfigsFinder) {
+        this.mixinConfigsFinder = mixinConfigsFinder;
+    }
 
     @Override
     public int getVersion() {
@@ -249,5 +255,9 @@ public class MixinExtrasServiceImpl implements MixinExtrasService {
             );
             return MixinExtrasVersion.V0_2_0_BETA_1;
         }
+    }
+    
+    public ResourceUtils.ConfigsFinder getMixinConfigsFinder() {
+        return mixinConfigsFinder;
     }
 }

--- a/src/main/java/com/llamalad7/mixinextras/utils/ResourceUtils.java
+++ b/src/main/java/com/llamalad7/mixinextras/utils/ResourceUtils.java
@@ -1,11 +1,12 @@
 package com.llamalad7.mixinextras.utils;
 
+import com.llamalad7.mixinextras.service.MixinExtrasService;
 import org.spongepowered.asm.service.MixinService;
 
 import java.io.InputStream;
 
-class ResourceUtils {
-    public static InputStream getResourceAsStream(String name) {
+public class ResourceUtils {
+    static InputStream getResourceAsStream(String name) {
         InputStream result = MixinService.getService().getResourceAsStream(name);
         if (result != null) {
             // Happy fast path
@@ -14,13 +15,21 @@ class ResourceUtils {
         // MixinServiceModLauncher is very poorly designed and relies heavily on the current TCCL
         // This might not be what we expect if we're running e.g. on a common worker thread
         ClassLoader oldTccl = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(ResourceUtils.class.getClassLoader());
+        Thread.currentThread().setContextClassLoader(MixinExtrasService.getInstance().getMixinConfigsFinder().getClassLoader());
 
         try {
             // See if we get a result with the transforming classloader
             return MixinService.getService().getResourceAsStream(name);
         } finally {
             Thread.currentThread().setContextClassLoader(oldTccl);
+        }
+    }
+    
+    public interface ConfigsFinder {
+        ClassLoader getClassLoader();
+        
+        static ConfigsFinder defaultConfigsFinder() {
+            return ResourceUtils.class::getClassLoader;
         }
     }
 }


### PR DESCRIPTION
Tested on neo 26.1.0.7-beta with a couple mods that use Mixin Extras with no adverse affects; neo seems to pick up the mixin jsons locating the plugin just fine, which was the most likely thing to break anyways.

Some context for those who did not see the discussion on discord: Having things that mixin loads at runtime (mixin plugins and things they reference) be `LIBRARY`, as opposed to `GAMELIBRARY`, is a good idea since otherwise the contract of `ClassProcessor`s running after mixin is broken -- they have to worry about changes they make potentially changing what mixin does, and (more importantly) cannot request from their bytecode provider and get mixin-transformed classes if they do so during certain class-loading-attempts (of mixin plugin classes), even if the class they request from the provider is entirely unrelated to the class being loaded.

Note: this PR additionally changes the neo repo from `https://maven.neoforged.net/` to `https://maven.neoforged.net/releases/`. I am not sure how it ever built with the former, seeing as that is not the neo repo's location? If I am missing something let me know and I'll revert that.